### PR TITLE
DX11 renderer first hacky implementation

### DIFF
--- a/gst-libs/mfx/d3d11/gstmfxwindow_d3d11.c
+++ b/gst-libs/mfx/d3d11/gstmfxwindow_d3d11.c
@@ -76,10 +76,11 @@ gst_mfx_window_d3d11_create (GstMfxWindow * window,
   return TRUE;
 }
 
-static void
-gst_mfx_window_d3d11_destroy (GstMfxWindow * window)
+static gboolean
+gst_mfx_window_d3d11_destroy (GObject * window)
 {
   GST_FIXME("unimplemented GstMfxWindowD3D11::destroy()");
+  return TRUE;
 }
 
 static gboolean

--- a/gst-libs/mfx/d3d11/gstmfxwindow_d3d11.c
+++ b/gst-libs/mfx/d3d11/gstmfxwindow_d3d11.c
@@ -1,6 +1,7 @@
 /*
  *  Copyright (C)
  *    Author: Ishmael Visayana Sameen <ishmael1985@gmail.com>
+ *    Author: Xavier Hallade <xavier.hallade@intel.com>
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public License
@@ -21,6 +22,7 @@
 #include "sysdeps.h"
 
 #include "gstmfxwindow_d3d11.h"
+#include "gstmfxwindow_d3d11_priv.h"
 #include "gstmfxwindow_priv.h"
 #include "gstmfxsurface.h"
 
@@ -30,26 +32,59 @@
 #define GST_MFX_WINDOW_D3D11_CAST(obj) \
 	((GstMfxWindowD3D11 *)(obj))
 
-struct _GstMfxWindowD3D11
-{
-  /*< private > */
-  GstMfxWindow parent_instance;
-};
-
-G_DEFINE_TYPE(GstMfxWindowD3D11, gst_mfx_window_d3d11, GST_TYPE_MFX_WINDOW);
 
 static gboolean
-gst_mfx_window_d3d11_render (GstMfxWindow * window,
+gst_mfx_window_d3d11_render (GstMfxWindow * mfx_window,
     GstMfxSurface * surface,
     const GstMfxRectangle * src_rect, const GstMfxRectangle * dst_rect)
 {
-  GST_FIXME("unimplemented GstMfxWindowD3D11::render()");
+  MSG msg;
+  GstMfxWindowPrivate *const priv = GST_MFX_WINDOW_GET_PRIVATE(mfx_window);
+  GstMfxWindowD3D11Private *const priv2 = GST_MFX_WINDOW_D3D11_GET_PRIVATE(mfx_window);
+
+
+  while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
+  {
+    // Translate the message and dispatch it to WindowProc()
+    TranslateMessage(&msg);
+    DispatchMessage(&msg);
+  }
+
+  // If the message is WM_QUIT, exit
+  if (msg.message == WM_QUIT) {
+    gst_mfx_window_d3d11_destroy(mfx_window);
+  }
+
+  if (!gst_mfx_surface_has_video_memory(surface)) {
+    D3D11_BOX destRegion;
+    destRegion.left = 0;
+    destRegion.right = priv->width;
+    destRegion.top = 0;
+    destRegion.bottom = priv->height;
+    destRegion.front = 0;
+    destRegion.back = 1;
+
+    ID3D11DeviceContext_UpdateSubresource(priv2->d3d11_device_ctx, priv2->backbuffer_texture,
+      0, &destRegion, gst_mfx_surface_get_plane(surface, 0),
+      gst_mfx_surface_get_pitch(surface, 0), 0);//TODO: ensure RGB4
+  }
+  else {
+    ID3D11DeviceContext_CopyResource(priv2->d3d11_device_ctx,
+      priv2->backbuffer_texture, (ID3D11Texture2D*) gst_mfx_surface_get_id(surface));
+  }
+
+  IDXGISwapChain1_Present(priv2->dxgi_swapchain, 0, 0);
+
   return TRUE;
 }
 
-gst_mfx_window_d3d11_show(GstMfxWindow * window)
+gst_mfx_window_d3d11_show(GstMfxWindow * mfx_window)
 {
-  GST_WARNING("unimplemented GstMfxWindowD3D11::show()");
+  GstMfxWindowD3D11Private *const priv2 = GST_MFX_WINDOW_D3D11_GET_PRIVATE(mfx_window);
+
+  ShowWindow(priv2->hwnd, SW_SHOWDEFAULT);
+  UpdateWindow(priv2->hwnd);
+
   return TRUE;
 }
 
@@ -68,11 +103,110 @@ gst_mfx_window_d3d11_set_fullscreen (GstMfxWindow * window,
   return TRUE;
 }
 
+
+LRESULT CALLBACK WindowProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+{
+  GstMfxWindow* window = (GstMfxWindow*)GetWindowLongPtr(hWnd, GWLP_USERDATA);
+
+  if (window)
+  {
+    switch (message)
+    {
+    case WM_DESTROY:
+      gst_mfx_window_d3d11_destroy(window);
+      break;
+    }
+  }
+
+  return DefWindowProc(hWnd, message, wParam, lParam);
+}
+
 static gboolean
-gst_mfx_window_d3d11_create (GstMfxWindow * window,
-    guint * width, guint * height)
+gst_mfx_window_d3d11_create (GstMfxWindow * mfx_window,
+  guint * width, guint * height)
 {
   GST_FIXME("unimplemented GstMfxWindowD3D11::create()");
+  GstMfxWindowPrivate *const priv = GST_MFX_WINDOW_GET_PRIVATE(mfx_window);
+  GstMfxWindowD3D11Private *const priv2 = GST_MFX_WINDOW_D3D11_GET_PRIVATE(mfx_window);
+
+
+  {
+#ifdef DEBUG
+    UINT creationFlags = D3D11_CREATE_DEVICE_DEBUG;
+#else
+    UINT creationFlags = 0;
+#endif
+
+    UINT adapter_idx = 0;
+    HRESULT hr = CreateDXGIFactory(&IID_IDXGIFactory, (void**)(&priv2->dxgi_factory));
+
+    while (IDXGIFactory2_EnumAdapters(priv2->dxgi_factory, adapter_idx, &priv2->dxgi_adapter) != DXGI_ERROR_NOT_FOUND)
+    {
+      DXGI_ADAPTER_DESC desc;
+      IDXGIAdapter_GetDesc(priv2->dxgi_adapter, &desc);
+      if (desc.VendorId == 0x8086) {//TODO: we can enable D3D11 rendering with frames on a separate device.
+        D3D11CreateDevice(priv2->dxgi_adapter, D3D_DRIVER_TYPE_UNKNOWN, NULL, creationFlags, NULL,
+          0, D3D11_SDK_VERSION, &priv2->d3d11_device, NULL, &priv2->d3d11_device_ctx);
+        break;
+      }
+      adapter_idx++;
+    }
+
+    WNDCLASS d3d11_window = { 0 };
+
+    d3d11_window.lpfnWndProc = (WNDPROC)WindowProc;
+    d3d11_window.hInstance = GetModuleHandle(NULL);;
+    d3d11_window.hCursor = LoadCursor(NULL, IDC_ARROW);
+    d3d11_window.lpszClassName = "GstMfxWindowD3D11";
+
+    if (!RegisterClass(&d3d11_window))
+      return FALSE;
+
+    priv2->hwnd = CreateWindowEx(0,
+      d3d11_window.lpszClassName,
+      "GstMfxWindow D3D11 Sink",
+      WS_OVERLAPPEDWINDOW,
+      CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+      NULL,
+      NULL,
+      d3d11_window.hInstance,
+      NULL);
+
+    g_return_val_if_fail(priv2->hwnd != NULL, FALSE);
+
+    SetWindowLongPtr(priv2->hwnd, GWLP_USERDATA, (LONG_PTR)mfx_window);
+
+    ShowWindow(priv2->hwnd, SW_SHOWDEFAULT);
+    UpdateWindow(priv2->hwnd);
+
+    DXGI_SWAP_CHAIN_DESC1 swapChainDesc = { 0 };
+
+    swapChainDesc.Width = *width;
+    swapChainDesc.Height = *height; 
+
+    swapChainDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM; //TODO: handle 10bpc with DXGI_FORMAT_R10G10B10A2_UNORM
+    swapChainDesc.SampleDesc.Count = 1; 
+    swapChainDesc.SampleDesc.Quality = 0;
+    swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+    swapChainDesc.BufferCount = 2;
+    swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+    swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+
+    hr = IDXGIFactory2_CreateSwapChainForHwnd(priv2->dxgi_factory,
+      priv2->d3d11_device,//TODO: check if should use D3D11Device or device context as priv->handle
+      priv2->hwnd,
+      &swapChainDesc,
+      NULL,
+      NULL,
+      &priv2->dxgi_swapchain);
+    g_return_val_if_fail(SUCCEEDED(hr), FALSE);
+
+    IDXGISwapChain1_GetBuffer(priv2->dxgi_swapchain, 0, &IID_ID3D11Texture2D, &priv2->backbuffer_texture);
+    g_return_val_if_fail(priv2->backbuffer_texture != NULL, FALSE);
+  }
+
+  //TODO: share device with input
+
   return TRUE;
 }
 

--- a/gst-libs/mfx/d3d11/gstmfxwindow_d3d11_priv.h
+++ b/gst-libs/mfx/d3d11/gstmfxwindow_d3d11_priv.h
@@ -1,0 +1,85 @@
+/*
+*  Copyright (C) 2017 Intel Corporation
+*    Author: Xavier Hallade <xavier.hallade@intel.com>
+*
+*  This library is free software; you can redistribute it and/or
+*  modify it under the terms of the GNU Lesser General Public License
+*  as published by the Free Software Foundation; either version 2.1
+*  of the License, or (at your option) any later version.
+*
+*  This library is distributed in the hope that it will be useful,
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+*  Lesser General Public License for more details.
+*
+*  You should have received a copy of the GNU Lesser General Public
+*  License along with this library; if not, write to the Free
+*  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+*  Boston, MA 02110-1301 USA
+*/
+
+#ifndef GST_MFX_WINDOW_D3D11_PRIV_H
+#define GST_MFX_WINDOW_D3D11_PRIV_H
+
+#define COBJMACROS 
+#include <dxgi1_2.h>
+#include <d3d11.h>
+
+#include "gstmfxwindow_d3d11.h"
+#include "gstmfxwindow_priv.h"
+
+G_BEGIN_DECLS
+
+#define GST_MFX_IS_WINDOW_D3D11(window) \
+  ((window) != NULL && \
+  GST_MFX_WINDOW_TYPE (window) == GST_MFX_WINDOW_TYPE_D3D11)
+
+#define GST_MFX_WINDOW_D3D11_CAST(window) \
+  ((GstMfxWindowD3D11 *)(window))
+
+#define GST_MFX_WINDOW_D3D11_GET_PRIVATE(window) \
+  (&GST_MFX_WINDOW_D3D11_CAST(window)->priv)
+
+
+typedef struct _GstMfxWindowD3D11Private   GstMfxWindowD3D11Private;
+
+struct _GstMfxWindowD3D11Private
+{
+  ID3D11Device *d3d11_device;
+  ID3D11DeviceContext *d3d11_device_ctx;
+  IDXGIFactory2 * dxgi_factory;
+  IDXGIAdapter2 * dxgi_adapter;
+  IDXGISwapChain1 * dxgi_swapchain;
+  ID3D11Texture2D * backbuffer_texture;
+  HWND hwnd;
+};
+
+/**
+* GstMfxWindowD3D11:
+*
+* MFX/D3D11 window wrapper.
+*/
+struct _GstMfxWindowD3D11
+{
+  /*< private >*/
+  GstMfxWindow parent_instance;
+
+  GstMfxWindowD3D11Private priv;
+};
+
+G_DEFINE_TYPE(GstMfxWindowD3D11, gst_mfx_window_d3d11, GST_TYPE_MFX_WINDOW);
+
+/**
+* GstMfxWindowD3D11Class:
+*
+* VA/Wayland display wrapper clas.
+*/
+struct _GstMfxWindowD3d11Class
+{
+  /*< private >*/
+  GstMfxWindowClass parent_class;
+};
+
+G_END_DECLS
+
+#endif /* GST_MFX_WINDOW_D3D11_PRIV_H */

--- a/gst-libs/mfx/gstmfxdecoder.c
+++ b/gst-libs/mfx/gstmfxdecoder.c
@@ -383,7 +383,7 @@ gst_mfx_decoder_create(GstMfxDecoder * decoder,
 	}
 
   /* Temporary for testing purposes */
-  decoder->params.IOPattern = MFX_IOPATTERN_OUT_SYSTEM_MEMORY;
+  decoder->params.IOPattern = MFX_IOPATTERN_OUT_SYSTEM_MEMORY; //TODO: remove
 	//decoder->params.IOPattern = MFX_IOPATTERN_OUT_VIDEO_MEMORY;
 	decoder->inited = FALSE;
 	decoder->bs.MaxLength = 1024 * 16;

--- a/gst-libs/mfx/gstmfxfilter.c
+++ b/gst-libs/mfx/gstmfxfilter.c
@@ -1010,6 +1010,9 @@ gst_mfx_filter_start (GstMfxFilter * filter)
   /* Get updated video params if modified by peer MFX element*/
   gst_mfx_task_update_video_params (filter->vpp[1], &filter->params);
 
+  /* Temporary for testing purposes */
+  filter->params.IOPattern = MFX_IOPATTERN_IN_SYSTEM_MEMORY | MFX_IOPATTERN_OUT_SYSTEM_MEMORY; //TODO: remove
+
   memtype_is_system = !(filter->params.IOPattern & MFX_IOPATTERN_OUT_VIDEO_MEMORY);
 
   request =  gst_mfx_task_get_request (filter->vpp[1]);

--- a/gst-libs/mfx/gstmfxsurface.c
+++ b/gst-libs/mfx/gstmfxsurface.c
@@ -138,7 +138,7 @@ error:
 }
 
 static void
-gst_mfx_surface_release_default (GstMfxSurface * surface)
+gst_mfx_surface_release_default (GObject * surface)
 {
   GstMfxSurfacePrivate *const priv = GST_MFX_SURFACE_GET_PRIVATE(surface);
   mfxFrameData *ptr = &priv->surface.Data;
@@ -256,7 +256,7 @@ gst_mfx_surface_create(GstMfxSurface * surface, const GstVideoInfo * info,
 }
 
 static void
-gst_mfx_surface_finalize (GstMfxSurface * surface)
+gst_mfx_surface_finalize (GObject * surface)
 {
   GstMfxSurfacePrivate *const priv = GST_MFX_SURFACE_GET_PRIVATE(surface);
   GstMfxSurfaceClass *klass = GST_MFX_SURFACE_GET_CLASS(surface);
@@ -264,7 +264,7 @@ gst_mfx_surface_finalize (GstMfxSurface * surface)
   if (priv->ext_buf)
     g_slice_free (mfxExtBuffer *, priv->ext_buf);
   if (klass->release)
-    klass->release(surface);
+    klass->release (surface);
   gst_mfx_task_replace (&priv->task, NULL);
 }
 

--- a/gst-libs/mfx/gstmfxsurface_priv.h
+++ b/gst-libs/mfx/gstmfxsurface_priv.h
@@ -69,7 +69,7 @@ struct _GstMfxSurface
 };
 
 typedef gboolean(*GstMfxSurfaceAllocateFunc) (GstMfxSurface * surface, GstMfxTask * task);
-typedef void(*GstMfxSurfaceReleaseFunc) (GstMfxSurface * surface);
+typedef void(*GstMfxSurfaceReleaseFunc) (GObject * surface);
 typedef gboolean(*GstMfxSurfaceMapFunc) (GstMfxSurface * surface);
 typedef void(*GstMfxSurfaceUnmapFunc) (GstMfxSurface * surface);
 

--- a/gst-libs/mfx/gstmfxwindow.c
+++ b/gst-libs/mfx/gstmfxwindow.c
@@ -77,6 +77,7 @@ gst_mfx_window_create (GstMfxWindow * window, guint width, guint height)
 {
   GstMfxWindowPrivate *const priv = GST_MFX_WINDOW_GET_PRIVATE(window);
 
+
   /* FIXME: Implement generic device context class to get display size*/
   //gst_mfx_display_get_size (window->display,
     //&window->display_width, &window->display_height);

--- a/gst-libs/mfx/gstmfxwindow.c
+++ b/gst-libs/mfx/gstmfxwindow.c
@@ -94,7 +94,7 @@ gst_mfx_window_create (GstMfxWindow * window, guint width, guint height)
 }
 
 static void
-gst_mfx_window_finalize (GstMfxWindow * window)
+gst_mfx_window_finalize (GObject * window)
 {
   GstMfxWindowClass *klass = GST_MFX_WINDOW_GET_CLASS (window);
 
@@ -225,7 +225,7 @@ gst_mfx_window_hide (GstMfxWindow * window)
 guintptr
 gst_mfx_window_get_handle (GstMfxWindow * window)
 {
-  g_return_val_if_fail (window != NULL, NULL);
+  g_return_val_if_fail (window != NULL, (guintptr)NULL);
 
   return GST_MFX_WINDOW_GET_PRIVATE(window)->handle;
 }

--- a/gst-libs/mfx/gstmfxwindow_priv.h
+++ b/gst-libs/mfx/gstmfxwindow_priv.h
@@ -81,7 +81,7 @@ struct _GstMfxWindow
 /* GstMfxWindowClass hooks */
 typedef gboolean(*GstMfxWindowCreateFunc) (GstMfxWindow * window,
   guint * width, guint * height);
-typedef gboolean(*GstMfxWindowDestroyFunc) (GstMfxWindow * window);
+typedef gboolean(*GstMfxWindowDestroyFunc) (GObject * window);
 typedef gboolean(*GstMfxWindowShowFunc) (GstMfxWindow * window);
 typedef gboolean(*GstMfxWindowHideFunc) (GstMfxWindow * window);
 typedef gboolean(*GstMfxWindowGetGeometryFunc) (GstMfxWindow * window,

--- a/gst-libs/mfx/meson.build
+++ b/gst-libs/mfx/meson.build
@@ -1,3 +1,5 @@
+additional_deps = []
+
 gst_mfx_libs_sources = [
   'gstmfxdecoder.c',
   'gstmfxencoder.c',
@@ -19,6 +21,10 @@ gst_mfx_libs_sources = [
 ]
 
 if get_option('USE_D3D11_RENDERER')
+  additional_deps += cc.find_library('dxgi')
+  additional_deps += cc.find_library('d3d11')
+  additional_deps += cc.find_library('dxguid')
+
   gst_mfx_libs_sources += 'd3d11/gstmfxwindow_d3d11.c'
 endif
 
@@ -29,12 +35,12 @@ gstmfx = library('gst-mfx-@0@'.format(api_version),
   version : libversion,
   soversion : soversion,
   install : true,
-  dependencies : [glib_deps, gst_dep, mfx_dep, gstvideo_dep],
+  dependencies : [glib_deps, gst_dep, mfx_dep, gstvideo_dep, additional_deps],
   vs_module_defs: vs_module_defs_dir + 'libgstmfx.def',
 )
 	
 gstmfx_dep = declare_dependency(link_with: gstmfx,
   include_directories : [libsinc],
-  dependencies : [gst_dep, mfx_dep],
+  dependencies : [gst_dep, mfx_dep, additional_deps],
   sources : gst_mfx_libs_sources)
   

--- a/gst/mfx/gstmfxsink.c
+++ b/gst/mfx/gstmfxsink.c
@@ -406,6 +406,10 @@ gst_mfxsink_set_caps (GstBaseSink * base_sink, GstCaps * caps)
 
   gst_caps_replace (&sink->caps, caps);
 
+  /* Temporary - in order to avoid scaling textures */
+  win_width = sink->video_width; //TODO: remove
+  win_height = sink->video_height;
+
   gst_mfxsink_ensure_window_size (sink, &win_width, &win_height);
   if (sink->window) {
     if (!sink->foreign_window || sink->fullscreen)


### PR DESCRIPTION
I'm not proud of it yet, but it's a start as it compiles and runs.
It uses system memory in decoder and vpp, and requires using vpp to get mfx RGB4 surfaces in.

sample usage:
```
%GSTREAMER_1_0_ROOT_X86_64%bin\gst-launch-1.0.exe ^
    --gst-plugin-load=gst_mfx.dll filesrc
    location=bbb_sunflower_2160p_30fps_normal.mp4^
     ! qtdemux ! h264parse ! mfxdecode ! mfxvpp^
     ! video/x-raw(memory:MFXSurface), format=BGRA ! mfxsinkelement
```