### PR TITLE
fixed rendering from video memory

### DIFF
--- a/gst-libs/mfx/d3d11/gstmfxwindow_d3d11.c
+++ b/gst-libs/mfx/d3d11/gstmfxwindow_d3d11.c
@@ -24,6 +24,7 @@
 #include "gstmfxwindow_d3d11_priv.h"
 #include "gstmfxwindow_priv.h"
 #include "gstmfxsurface.h"
+#include "gstmfxallocator_d3d11.h"
 
 #define DEBUG 1
 #include "gstmfxdebug.h"
@@ -74,10 +75,16 @@ gst_mfx_window_d3d11_render (GstMfxWindow * mfx_window,
       gst_mfx_surface_get_pitch(surface, 0), 0);//TODO: ensure RGB4*/
   }
   else {
+
+
+    mfxFrameSurface1* frame = (ID3D11Texture2D*)gst_mfx_surface_get_frame_surface(surface);
+    mfxHDLPair pair;
+    gst_mfx_task_frame_get_hdl(NULL, frame->Data.MemId, &pair);
+
     ID3D11DeviceContext_CopyResource(
       gst_mfx_device_get_d3d11_context(priv2->device),
       priv2->backbuffer_texture,
-      (ID3D11Texture2D*)gst_mfx_surface_get_id(surface));
+      (ID3D11Texture2D*) pair.first);
 
     /*ID3D11DeviceContext_CopyResource(priv2->d3d11_device_ctx,
       priv2->backbuffer_texture, (ID3D11Texture2D*) gst_mfx_surface_get_id(surface));*/
@@ -274,5 +281,6 @@ gst_mfx_window_d3d11_new (GstMfxWindowD3D11 * window, GstMfxContext * context,
       gst_mfx_context_get_device(context);
 
   return gst_mfx_window_new_internal (GST_MFX_WINDOW(window), context,
-    GST_MFX_ID_INVALID, width, height);
+    //GST_MFX_ID_INVALID, 
+    width, height);
 }

--- a/gst-libs/mfx/gstmfxallocator_d3d11.c
+++ b/gst-libs/mfx/gstmfxallocator_d3d11.c
@@ -49,7 +49,7 @@ gst_mfx_task_frame_alloc(mfxHDL pthis, mfxFrameAllocRequest * request,
   if (task->task_type & (GST_MFX_TASK_VPP_OUT | GST_MFX_TASK_DECODER))
   request->Type |= 0x1000;*/
 
-  if (priv->saved_responses && priv->task_type & GST_MFX_TASK_DECODER) {
+  if (priv->saved_responses && (priv->task_type & GST_MFX_TASK_DECODER) == GST_MFX_TASK_DECODER) {
     GList *l = g_list_last(priv->saved_responses);
     if (l) {
       response_data = l->data;

--- a/gst-libs/mfx/gstmfxcontext.c
+++ b/gst-libs/mfx/gstmfxcontext.c
@@ -92,7 +92,7 @@ gst_mfx_context_replace (GstMfxContext ** old_context_ptr,
 	  GST_OBJECT(new_context));
 }
 
-guintptr
+GstMfxDevice*
 gst_mfx_context_get_device(GstMfxContext * context)
 {
   return context->device;

--- a/gst-libs/mfx/gstmfxcontext.h
+++ b/gst-libs/mfx/gstmfxcontext.h
@@ -22,6 +22,7 @@
 #define GST_MFX_CONTEXT_H
 
 #include "sysdeps.h"
+#include "d3d11/gstmfxdevice.h"
 
 G_BEGIN_DECLS
 
@@ -43,7 +44,7 @@ void
 gst_mfx_context_replace (GstMfxContext ** old_context_ptr,
     GstMfxContext * new_context);
 
-guintptr
+GstMfxDevice*
 gst_mfx_context_get_device(GstMfxContext * context);
 
 G_END_DECLS

--- a/gst-libs/mfx/gstmfxsurface_d3d11.h
+++ b/gst-libs/mfx/gstmfxsurface_d3d11.h
@@ -36,7 +36,8 @@ G_DECLARE_FINAL_TYPE(GstMfxSurfaceD3D11, gst_mfx_surface_d3d11, GST_MFX, SURFACE
   GstMfxSurfaceD3D11Class))
 
 GstMfxSurface *
-gst_mfx_surface_d3d11_new_from_task(GstMfxTask * task);
+gst_mfx_surface_d3d11_new_from_task(GstMfxSurfaceD3D11 * surface,
+  GstMfxTask * task);
 
 G_END_DECLS
 

--- a/gst-libs/mfx/gstmfxtask.h
+++ b/gst-libs/mfx/gstmfxtask.h
@@ -22,6 +22,7 @@
 #define GST_MFX_TASK_H
 
 #include "gstmfxcontext.h"
+#include "gstmfxtypes.h"
 #include "sysdeps.h"
 
 G_BEGIN_DECLS
@@ -80,6 +81,9 @@ gst_mfx_task_set_task_type (GstMfxTask * task, guint flags);
 
 guint
 gst_mfx_task_get_task_type (GstMfxTask * task);
+
+GstMfxMemoryId *
+gst_mfx_task_get_memory_id (GstMfxTask * task);
 
 void
 gst_mfx_task_use_video_memory (GstMfxTask * task);

--- a/gst-libs/mfx/gstmfxwindow.c
+++ b/gst-libs/mfx/gstmfxwindow.c
@@ -118,7 +118,7 @@ gst_mfx_window_class_init (GstMfxWindowClass * klass)
 
 GstMfxWindow *
 gst_mfx_window_new_internal (GstMfxWindow *window, GstMfxContext * context,
-  GstMfxID id, guint width, guint height)
+  /*GstMfxID id,*/ guint width, guint height)
 {
   /*if (id != GST_MFX_ID_INVALID) {
     g_return_val_if_fail (width == 0, NULL);
@@ -126,11 +126,11 @@ gst_mfx_window_new_internal (GstMfxWindow *window, GstMfxContext * context,
   } else {
     g_return_val_if_fail (width > 0, NULL);
     g_return_val_if_fail (height > 0, NULL);
-  }*/
+  }
 
   GST_MFX_WINDOW_GET_PRIVATE(window)->handle = id;
   GST_MFX_WINDOW_GET_PRIVATE(window)->use_foreign_window =
-      id != GST_MFX_ID_INVALID;
+      id != GST_MFX_ID_INVALID;*/
   GST_MFX_WINDOW_GET_PRIVATE(window)->context =
     gst_mfx_context_ref(context);
   if (!gst_mfx_window_create (window, width, height))

--- a/gst-libs/mfx/gstmfxwindow_priv.h
+++ b/gst-libs/mfx/gstmfxwindow_priv.h
@@ -128,7 +128,7 @@ gst_mfx_window_class_init(GstMfxWindowClass * klass);
 GstMfxWindow *
 gst_mfx_window_new_internal(GstMfxWindow * window,
   //GstMfxDisplay * display,
-  GstMfxID handle, guint width, guint height);
+  GstMfxContext* handle, guint width, guint height);
 
 #define gst_mfx_window_ref_internal(window) \
   ((gpointer)gst_object_ref(GST_OBJECT(window)))


### PR DESCRIPTION
works without mfxvpp at the moment:

gst-launch-1.0.exe --gst-plugin-load=gst\mfx\gst_mfx.dll
filesrc
location="bbb_sunflower_2160p_30fps_normal.mp4" !
qtdemux ! h264parse ! mfxdecode ! video/x-raw(memory:MFXSurface),
format=BGRA ! mfxsinkelement