### PR TITLE
compile modules separately and remove absolute paths

### DIFF
--- a/gst-libs/mfx/meson.build
+++ b/gst-libs/mfx/meson.build
@@ -76,8 +76,12 @@ if mfx_encoder
   endforeach
 endif
 
+gstmfx_libs_tag = static_library('gstmfx-@0@'.format(api_version),
+  sources,
+  c_args : gst_mfx_args,
+  include_directories : config_inc,
+  dependencies : gst_mfx_deps,
+)
 
-foreach s: sources
-  gst_mfx_sources += ['@0@/@1@'.format(meson.current_source_dir(), s)]
-endforeach
-  
+gstmfx_libs_dep = declare_dependency(link_with: gstmfx_libs_tag,
+  include_directories : [config_inc, include_directories('.')])

--- a/gst/mfx/meson.build
+++ b/gst/mfx/meson.build
@@ -72,6 +72,11 @@ else
   endforeach
 endif
 
-foreach s: sources
-  gst_mfx_sources += ['@0@/@1@'.format(meson.current_source_dir(), s)]
-endforeach
+gstmfxtag = library('gstmfx',
+  sources,
+  c_args : gst_mfx_args,
+  include_directories : include_directories('.'),
+  dependencies : [gst_mfx_deps, gstmfx_libs_dep],
+  install : true,
+  install_dir : plugins_install_dir,
+)

--- a/meson.build
+++ b/meson.build
@@ -118,7 +118,7 @@ else
   gst_mfx_deps += cc.find_library('dl')
 endif
 
-mfx_inc = include_directories(['.', 'gst/mfx', 'gst-libs/mfx', 'parsers', '@0@/include'.format(mfx_home)])
+config_inc = include_directories('.')
 
 mfx_decoder = get_option('MFX_DECODER')
 if mfx_decoder
@@ -195,12 +195,3 @@ configure_file(input : 'version.h.in',
 subdir('gst-libs')
 subdir('parsers')
 subdir('gst')
-
-gstmfxtag = library('gstmfx',
-  gst_mfx_sources,
-  c_args : gst_mfx_args,
-  include_directories : mfx_inc,
-  dependencies : gst_mfx_deps,
-  install : true,
-  install_dir : plugins_install_dir,
-)

--- a/parsers/meson.build
+++ b/parsers/meson.build
@@ -1,8 +1,24 @@
 if get_option ('MFX_VC1_PARSER')
   if with_codecparsers and with_pbutils
-    gst_mfx_args += ['-DMFX_VC1_PARSER']
-    gst_mfx_deps += [gstcodecparsers_dep, gstpbutils_dep]
-    gst_mfx_sources += ['@0@/@1@'.format(meson.current_source_dir(), 'gstvc1parse.c')]
+    sources = [
+      'gstvc1parse.c',
+    ]
+
+  gstmfxvc1parse = static_library('gst-mfx-vc1parse-@0@'.format(api_version),
+    sources,
+    c_args : gst_mfx_args,
+    include_directories: include_directories('.'),
+    version : libversion,
+    dependencies : [glib_deps, gst_dep, gstbase_dep, mfx_dep, gstvideo_dep, gstcodecparsers_dep, gstpbutils_dep],
+  )
+
+  gstmfxvc1parse_dep = declare_dependency(link_with: gstmfxvc1parse,
+    include_directories : include_directories('.'),
+    dependencies : [gst_dep, mfx_dep, gstcodecparsers_dep, gstpbutils_dep])
+
+  gst_mfx_args += ['-DMFX_VC1_PARSER']
+  gst_mfx_deps += [gstmfxvc1parse_dep]
+
   elif get_option ('MFX_VC1_PARSER')
     error ('MFX_VC1_PARSER required, but pbutils or codecparsers are not present')
   endif


### PR DESCRIPTION
absolute paths cause problems on Windows. ninja builds were always dirty on my system with any meson version.
I think it's cleaner to compile gst/gst-libs/parsers separately.
I've also removed some redundant dependency declarations.