### PR TITLE
supporting mfx_dispatch from MediaSDK OSS and gcc-6.3 compilation

### DIFF
--- a/gst-libs/mfx/gstmfxsurface_d3d11.c
+++ b/gst-libs/mfx/gstmfxsurface_d3d11.c
@@ -219,7 +219,7 @@ gst_mfx_surface_d3d11_unmap(GstMfxSurface * surface)
 }
 
 void
-gst_mfx_surface_d3d11_class_init(GstMfxSurfaceClass * klass)
+gst_mfx_surface_d3d11_class_init(GstMfxSurfaceD3D11Class * klass)
 {
   GstMfxSurfaceClass *const surface_class = GST_MFX_SURFACE_CLASS(klass);
 

--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,7 @@ libversion = '@0@.@1@.0'.format(soversion, gst_version_minor.to_int() * 100 + gs
 plugins_install_dir = '@0@/gstreamer-1.0'.format(get_option('libdir'))
 
 cc = meson.get_compiler('c')
+cxx = meson.get_compiler('cpp')
 
 if cc.get_id() == 'msvc'
   # Ignore several spurious warnings for things gstreamer does very commonly
@@ -101,18 +102,22 @@ if mfx_dep.found() == false # otherwise look into Media SDK/Media Server Studio 
   if mfx_home != ''
     mfx_libdir = [mfx_home + '/lib/lin_x64', mfx_home + '/lib/x64']
     mfx_incdir = include_directories(mfx_home + '/include')
-    mfx_lib = cc.find_library('mfx', dirs: mfx_libdir)
-    mfx_dep = declare_dependency(include_directories: mfx_incdir, dependencies: [mfx_lib])
+    mfx_lib = cxx.find_library('mfx', dirs: mfx_libdir)
+    if host_machine.system() == 'windows' # windows Media SDK / Media Server Studio prebuilt lib requires legacy_stdio_definitions
+      legacy_stdio_dep = cc.find_library('legacy_stdio_definitions')
+      mfx_dep = declare_dependency(include_directories: mfx_incdir, dependencies: [mfx_lib, legacy_stdio_dep])
+    else
+      mfx_dep = declare_dependency(include_directories: mfx_incdir, dependencies: mfx_lib)
+    endif
   endif
 endif
 
 gst_mfx_deps += mfx_dep
 
 if host_machine.system() == 'windows'
-  legacy_stdio_dep = cc.find_library('legacy_stdio_definitions')
-  d3d11_dep = cc.find_library('d3d11')
-  gst_mfx_deps += [legacy_stdio_dep, d3d11_dep]
+  gst_mfx_deps += cc.find_library('d3d11')
   gst_mfx_args += ['-DWITH_D3D11_BACKEND']
+  gst_mfx_deps += cc.find_library('stdc++')
 else
   driver_deps = [dependency ('libva'), dependency ('libdrm'), dependency ('libdrm_intel'),
     dependency ('libva-drm'), dependency('libudev')]
@@ -126,7 +131,7 @@ else
     gst_mfx_args += ['-DHAVE_GST_GL_LIBS']
   endif
   gst_mfx_args += ['-DWITH_LIBVA_BACKEND']
-  gst_mfx_args += ['-std=gnu99']
+  #gst_mfx_args += ['-std=gnu99']
 endif
 
 config_inc = include_directories('.')


### PR DESCRIPTION
```
git clone https://github.com/ph0b/MediaSDK # (https://github.com/Intel-Media-SDK/MediaSDK when https://github.com/Intel-Media-SDK/MediaSDK/pull/11 gets merged)
cd MediaSDK/api/opensource/mfx_dispatch
## remove get_mfx_version(MFX_VERSION_MAJOR MFX_VERSION_MINOR) to set these vars manually
mkdir build && cd build && cmake .. -DCMAKE_INSTALL_PREFIX=/mingw64/
make && make install

export PKG_CONFIG_PATH=/mingw64/lib/lin_x86/pkgconfig/:$PKG_CONFIG_PATH
#now build gstreamer-media-sdk
```

This approach also works with https://github.com/lu-zero/mfx_dispatch if using libmfx instead of mfx for pkg-config lookup in meson.build.