### PR TITLE
Added encoding colorimetry

### DIFF
--- a/gst-libs/mfx/gstmfxencoder_priv.h
+++ b/gst-libs/mfx/gstmfxencoder_priv.h
@@ -187,8 +187,8 @@ struct _GstMfxEncoderPrivate
   mfxExtCodingOption extco;
   mfxExtCodingOption2 extco2;
   mfxExtHEVCParam exthevc;
-  mfxExtBuffer *extparam_internal[3];
-  int nb_extparam_internal;
+  mfxExtVideoSignalInfo extsig;
+  mfxExtBuffer *extparam_internal[4];
 
   /* H264 specific coding options */
   gboolean use_cabac;


### PR DESCRIPTION
This uses colorimetry specification present in the gstreamer caps to tell the encoder to add SEI information into the encoded bitstream. This SEI data is used by decoders.